### PR TITLE
fix: address -Wmissing-prototypes warnings on kernel 6.12

### DIFF
--- a/virtio_lo_device.c
+++ b/virtio_lo_device.c
@@ -24,7 +24,7 @@
 
 static void virtio_lo_add_pdev(struct work_struct *work);
 
-void vl_device_parent_release(struct device *dev)
+static void vl_device_parent_release(struct device *dev)
 {
 }
 

--- a/virtio_lo_driver.c
+++ b/virtio_lo_driver.c
@@ -14,6 +14,7 @@
 #include <linux/virtio_ring.h>
 #include <linux/version.h>
 #include "virtio_lo_device.h"
+#include "virtio_lo_driver.h"
 
 /* The alignment to use between consumer and producer parts of vring.
  * Currently hardcoded to the page size. */


### PR DESCRIPTION
Kernel 6.12 enables -Wmissing-prototypes by default, causing module builds to fail when warnings are treated as errors.

Mark vl_device_parent_release() as static since it is only used within virtio_lo_device.c.

Include virtio_lo_driver.h in virtio_lo_driver.c so the existing prototype for is_name_in_virtio_lo_table() is visible at the point of definition.